### PR TITLE
An abstract implementation of the Message, Request, and Response interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,18 @@
     ],
     "autoload": {
         "psr-4": {
-            "Psr\\Http\\Message\\": "src"
+            "Psr\\Http\\Message\\": [
+                "src",
+                "test"
+            ]
         }
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.3"
     }
 }

--- a/src/AbstractMessage.php
+++ b/src/AbstractMessage.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Psr\Http\Message;
+
+abstract class AbstractMessage implements MessageInterface
+{
+    /**
+     * @var StreamableInterface|null
+     */
+    protected $body;
+
+    /**
+     * @var array
+     */
+    protected $headers = [];
+
+    /**
+     * @var string
+     */
+    protected $protocolVersion;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getProtocolVersion()
+    {
+        return $this->protocolVersion;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setProtocolVersion($version)
+    {
+        $this->protocolVersion = $version;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setBody(StreamableInterface $body = null)
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasHeader($header)
+    {
+        return isset($this->headers[strtolower($header)]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getHeader($header)
+    {
+        return !$this->hasHeader($header) ? '' : implode(',', $this->getHeaderAsArray($header));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getHeaderAsArray($header)
+    {
+        return (!$this->hasHeader($header)) ? [] : $this->headers[strtolower($header)];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setHeader($header, $value)
+    {
+        if (!is_string($header)) {
+            throw new \InvalidArgumentException('Header field name must be a string.');
+        }
+
+        $header = strtolower($header);
+
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+
+        foreach ($value as $headerValue) {
+            if (!is_string($headerValue)) {
+                throw new \InvalidArgumentException('Header field value must be a string or array of strings.');
+            }
+        }
+
+        $this->headers[strtolower($header)] = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addHeader($header, $value)
+    {
+        if (!is_string($header)) {
+            throw new \InvalidArgumentException('Header field name must be a string.');
+        }
+
+        $value = (array) $value;
+        $this->setHeader($header, array_merge($this->getHeaderAsArray($header), $value));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function removeHeader($header)
+    {
+        unset($this->headers[strtolower($header)]);
+    }
+}

--- a/src/AbstractRequest.php
+++ b/src/AbstractRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Psr\Http\Message;
+
+abstract class AbstractRequest extends AbstractMessage implements RequestInterface
+{
+    /**
+     * @var string
+     */
+    protected $method;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setMethod($method)
+    {
+        if (!is_string($method)) {
+            throw new \InvalidArgumentException('HTTP Request method must be a string.');
+        }
+
+        $this->method = $method;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUrl($url)
+    {
+        if (!is_string($url) && (!is_object($url) || !method_exists($url, '__toString'))) {
+            throw new \InvalidArgumentException('URL must be string or implement the __toString method.');
+        }
+
+        if (!$this->validateUrl($url)) {
+            throw new \InvalidArgumentException('URL must be absolute and conform to RFC 3986.');
+        }
+
+        $this->url = $url;
+    }
+
+    /**
+     * Returns whether or not the URL conforms to RFC 3986. The choice of
+     * validation method is an implementation detail left to the consumer.
+     *
+     * @param string|object $url Request URL
+     * @return boolean
+     */
+    abstract protected function validateUrl($url);
+}

--- a/src/AbstractResponse.php
+++ b/src/AbstractResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Psr\Http\Message;
+
+abstract class AbstractResponse extends AbstractMessage implements ResponseInterface
+{
+    /**
+     * @var string
+     */
+    protected $reasonPhrase;
+
+    /**
+     * @var int
+     */
+    protected $statusCode;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setStatusCode($code)
+    {
+        if (!is_int($code)) {
+            throw new \InvalidArgumentException('HTTP status code must be an integer.');
+        }
+
+        $this->statusCode = $code;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReasonPhrase()
+    {
+        return $this->reasonPhrase;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setReasonPhrase($phrase)
+    {
+        if (!is_string($phrase)) {
+            throw new \InvalidArgumentException('Reason Phrase must be a string.');
+        }
+
+        $this->reasonPhrase = $phrase;
+    }
+}

--- a/test/AbstractMessageTest.php
+++ b/test/AbstractMessageTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Psr\Http\Message;
+
+use Psr\Http\Message\TestAsset\ConcreteMessage;
+
+class AbstractMessageTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AbstractMessage
+     */
+    protected $message;
+
+    public function testCanGetAndSetProtocolVersion()
+    {
+        $this->assertNull($this->message->getProtocolVersion());
+        $this->message->setProtocolVersion('HTTP/1.1');
+        $this->assertSame('HTTP/1.1', $this->message->getProtocolVersion());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Header field name must be a string.
+     */
+    public function testInvalidArgumentExceptionIsThrownWhenAttemptingToSetInvalidHeader()
+    {
+        $this->message->setHeader($this, 'bar');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Header field name must be a string.
+     */
+    public function testInvalidArgumentExceptionIsThrownWhenAttemptingToAddInvalidHeader()
+    {
+        $this->message->addHeader($this, 'bar');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Header field value must be a string or array of strings.
+     */
+    public function testInvalidArgumentExceptionIsThrownWhenAttemptingToSetNonStringHeaderValues()
+    {
+        $this->message->setHeader('Accept', $this);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Header field value must be a string or array of strings.
+     */
+    public function testInvalidArgumentExceptionIsThrownWhenAttemptingToAddNonStringHeaderValues()
+    {
+        $this->message->addHeader('hello-world', $this);
+    }
+
+    public function testCanSetHeaderValuesAsStrings()
+    {
+        $this->message->setHeader('hello-world', 'hello!');
+        $this->assertSame('hello!', $this->message->getHeader('hello-world'));
+    }
+
+    public function testCanSetHeaderValuesAsArrayOfStrings()
+    {
+        $this->message->setHeader('hello-world', ['hello!', 'world!']);
+        $this->assertSame('hello!,world!', $this->message->getHeader('hello-world'));
+    }
+
+    public function testSettingHttpHeaderReplacesPreviouslySetHeadersOfTheSameType()
+    {
+        $this->message->setHeader('hello-world', ['hello!']);
+        $this->message->setHeader('hello-world', ['goodbye!']);
+
+        $this->assertSame('goodbye!', $this->message->getHeader('hello-world'));
+    }
+
+    public function testAddingHttpHeaderAppendsToExistingHeadersOfTheSameType()
+    {
+        $this->message->addHeader('hello-world', ['hello!']);
+        $this->message->addHeader('hello-world', ['goodbye!']);
+
+        $this->assertSame('hello!,goodbye!', $this->message->getHeader('hello-world'));
+    }
+
+    public function testGetHeadersReturnsHeadersWithFieldNamesAsKeysAndValuesAsArraysOfStrings()
+    {
+        $this->message->setHeader('hello-world', ['hello!', 'goodbye!']);
+        $this->message->setHeader('foobar', ['foo', 'bar']);
+        $this->assertSame(
+            [
+                'hello-world' => ['hello!', 'goodbye!'],
+                'foobar' => ['foo', 'bar']
+            ],
+            $this->message->getHeaders()
+        );
+    }
+
+    public function testCanRemovePreviouslySetHeaders()
+    {
+        $this->message->setHeader('foobar', ['foo', 'bar']);
+        $this->message->removeHeader('foobar');
+        $this->assertFalse($this->message->hasHeader('foobar'));
+    }
+
+    public function fieldNameProvider()
+    {
+        return [
+            ['foobar'],
+            ['FooBar'],
+            ['FOOBAR'],
+            ['FoObAr'],
+        ];
+    }
+
+    /**
+     * @dataProvider fieldNameProvider
+     */
+    public function testHeaderFieldNameHandlingIsCaseInsensitive($fieldName)
+    {
+        $lcFieldName = strtolower($fieldName);
+
+        $this->message->setHeader($fieldName, 'foo');
+        $this->message->addHeader($fieldName, 'bar');
+
+        $this->assertSame(
+            $this->message->hasHeader($fieldName),
+            $this->message->hasHeader($lcFieldName)
+        );
+        $this->assertSame(
+            $this->message->getHeader($fieldName),
+            $this->message->getHeader($lcFieldName)
+        );
+        $this->assertSame(
+            $this->message->getHeaderAsArray($fieldName),
+            $this->message->getHeaderAsArray($lcFieldName)
+        );
+
+        $this->message->removeHeader($fieldName);
+
+        $this->assertFalse($this->message->hasHeader($fieldName));
+        $this->assertSame(
+            $this->message->hasHeader($fieldName),
+            $this->message->hasHeader($lcFieldName)
+        );
+    }
+
+    public function bodyProvider()
+    {
+        return [
+            [null],
+            [$this->getMockForAbstractClass('Psr\Http\Message\StreamableInterface', [], '', false)],
+        ];
+    }
+
+    /**
+     * @dataProvider bodyProvider
+     */
+    public function testCanGetAndSetBody($body)
+    {
+        $this->message->setBody($body);
+        $this->assertSame($body, $this->message->getBody());
+    }
+
+    protected function setUp()
+    {
+        $this->message = new ConcreteMessage();
+    }
+
+    protected function tearDown()
+    {
+        $this->message = null;
+    }
+}

--- a/test/AbstractRequestTest.php
+++ b/test/AbstractRequestTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Psr\Http\Message;
+
+use Psr\Http\Message\TestAsset\ConcreteRequest;
+use Psr\Http\Message\TestAsset\Url;
+
+class AbstractRequestTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AbstractRequest
+     */
+    protected $request;
+
+    public function testCanGetAndSetMethod()
+    {
+        $this->request->setMethod('get');
+        $this->assertSame('get', $this->request->getMethod());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage HTTP Request method must be a string.
+     */
+    public function testInvalidArgumentExceptionIsThrownWhenAttemptingToSetInvalidHttpMethod()
+    {
+        $this->request->setMethod($this);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage URL must be string or implement the __toString method.
+     */
+    public function testInvalidArgumentExceptionIsThrownIfUrlIsNeitherStringNorImplementorOfToString()
+    {
+        $this->request->setUrl($this);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage URL must be absolute and conform to RFC 3986.
+     */
+    public function testInvalidArgumentExceptionIsThrownIfUrlIsNotValid()
+    {
+        $this->request->setUrl('invalid');
+    }
+
+    public function validUrlProvider()
+    {
+        return [
+            [ConcreteRequest::$validUrl],
+            [new Url()],
+        ];
+    }
+
+    /**
+     * @dataProvider validUrlProvider
+     */
+    public function testCanSetValidUrl($url)
+    {
+        $this->request->setUrl($url);
+        $this->assertEquals($url, $this->request->getUrl());
+    }
+
+    protected function setUp()
+    {
+        $this->request = new ConcreteRequest();
+    }
+
+    protected function tearDown()
+    {
+        $this->request = null;
+    }
+}

--- a/test/AbstractResponseTest.php
+++ b/test/AbstractResponseTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Psr\Http\Message;
+
+use Psr\Http\Message\TestAsset\ConcreteResponse;
+
+class AbstractResponseTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AbstractResponse
+     */
+    protected $response;
+
+    public function testCanGetAndSetStatusCode()
+    {
+        $this->response->setStatusCode(200);
+        $this->assertSame(200, $this->response->getStatusCode());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage HTTP status code must be an integer.
+     */
+    public function testInvalidArgumentExceptionIsThrownWhenAttemptingToSetInvalidStatusCode()
+    {
+        $this->response->setStatusCode($this);
+    }
+
+    public function testCanGetAndSetReasonPhrase()
+    {
+        $this->response->setReasonPhrase('because!');
+        $this->assertSame('because!', $this->response->getReasonPhrase());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Reason Phrase must be a string.
+     */
+    public function testInvalidArgumentExceptionIsThrownWhenAttemptingToSetInvalidReasonPhrase()
+    {
+        $this->response->setReasonPhrase($this);
+    }
+
+    protected function setUp()
+    {
+        $this->response = new ConcreteResponse();
+    }
+
+    protected function tearDown()
+    {
+        $this->response = null;
+    }
+}

--- a/test/TestAsset/ConcreteMessage.php
+++ b/test/TestAsset/ConcreteMessage.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psr\Http\Message\TestAsset;
+
+use Psr\Http\Message\AbstractMessage;
+
+class ConcreteMessage extends AbstractMessage
+{
+}

--- a/test/TestAsset/ConcreteRequest.php
+++ b/test/TestAsset/ConcreteRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Psr\Http\Message\TestAsset;
+
+use Psr\Http\Message\AbstractRequest;
+
+class ConcreteRequest extends AbstractRequest
+{
+    public static $validUrl = 'https://github.com/php-fig/http-message';
+
+    /**
+     * Stub validator for testing purposes.
+     *
+     * @param string|object $url Request URL
+     * @return boolean
+     */
+    protected function validateUrl($url)
+    {
+        return $url == self::$validUrl;
+    }
+}

--- a/test/TestAsset/ConcreteResponse.php
+++ b/test/TestAsset/ConcreteResponse.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psr\Http\Message\TestAsset;
+
+use Psr\Http\Message\AbstractResponse;
+
+class ConcreteResponse extends AbstractResponse
+{
+}

--- a/test/TestAsset/Url.php
+++ b/test/TestAsset/Url.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Psr\Http\Message\TestAsset;
+
+class Url
+{
+    public function __toString()
+    {
+        return ConcreteRequest::$validUrl;
+    }
+}


### PR DESCRIPTION
Following the precedent set by [`Psr\Log\AbstractLogger`](https://github.com/php-fig/log/blob/master/Psr/Log/AbstractLogger.php), I created some simple, generic, abstract implementations of the Message, Request, and Response interfaces. This would allow developers to begin writing PSR-7 compatible wrappers around their favorite HTTP libraries while the proposal moves forward.

A few things to note:

1. It was not clear to me if, for example, `"@throws \InvalidArgumentException for invalid header names or values."` in the interface docblocks meant "non-string" or if it meant to literally check against a whitelist of valid HTTP header field names. As such, I simply went the type-checking route, which can be expanded to include checking against a whitelist if that is the intention.
2. I have `AbstractRequest` validating URLs using a `validateUrl(...)` method that the extending `RequestInterface` class must implement. It seemed to me that validating a URL against RFC 3986 was beyond the scope of what this PSR aims to accomplish (and there are plenty of libraries for doing that anyway).
3. I haven't dealt with `IncomingRequestInterface` or `StreamableInterface` yet, so this is just a starting point. I can work on that (or invite anyone else to do so, naturally) if this PR generates interest.
4. Integration with Travis might be a good idea to ensure the Abstract implementations don't break if the Interfaces continue to evolve.

Feedback welcome!