### PR TITLE
setBody() MUST receive a StreamableInterface

### DIFF
--- a/src/OutgoingRequestInterface.php
+++ b/src/OutgoingRequestInterface.php
@@ -111,12 +111,11 @@ interface OutgoingRequestInterface extends MessageInterface
     /**
      * Sets the body of the message.
      *
-     * The body MUST be a StreamableInterface object. Setting the body to null MUST
-     * remove the existing body.
+     * The body MUST be a StreamableInterface object.
      *
-     * @param StreamableInterface|null $body Body.
+     * @param StreamableInterface $body Body.
      * @return void
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function setBody(StreamableInterface $body = null);
+    public function setBody(StreamableInterface $body);
 }

--- a/src/OutgoingResponseInterface.php
+++ b/src/OutgoingResponseInterface.php
@@ -109,12 +109,11 @@ interface OutgoingResponseInterface extends MessageInterface
     /**
      * Sets the body of the message.
      *
-     * The body MUST be a StreamableInterface object. Setting the body to null MUST
-     * remove the existing body.
+     * The body MUST be a StreamableInterface object.
      *
-     * @param StreamableInterface|null $body Body.
+     * @param StreamableInterface $body Body.
      * @return void
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function setBody(StreamableInterface $body = null);
+    public function setBody(StreamableInterface $body);
 }


### PR DESCRIPTION
- null is no longer allowed (per the ML; see also php-fig/fig-standards#367).
