### PR TITLE
[PSR-7] Changed verbiage of $header and $attribute arguments

### DIFF
--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -69,12 +69,12 @@ interface MessageInterface
     /**
      * Checks if a header exists by the given case-insensitive name.
      *
-     * @param string $header Case-insensitive header name.
+     * @param string $name Case-insensitive header field name.
      * @return bool Returns true if any header names match the given header
      *     name using a case-insensitive string comparison. Returns false if
      *     no matching header name is found in the message.
      */
-    public function hasHeader($header);
+    public function hasHeader($name);
 
     /**
      * Retrieve a header by the given case-insensitive name, as a string.
@@ -87,18 +87,18 @@ interface MessageInterface
      * comma concatenation. For such headers, use getHeaderLines() instead
      * and supply your own delimiter when concatenating.
      *
-     * @param string $header Case-insensitive header name.
+     * @param string $name Case-insensitive header field name.
      * @return string
      */
-    public function getHeader($header);
+    public function getHeader($name);
 
     /**
      * Retrieves a header by the given case-insensitive name as an array of strings.
      *
-     * @param string $header Case-insensitive header name.
+     * @param string $name Case-insensitive header field name.
      * @return string[]
      */
-    public function getHeaderLines($header);
+    public function getHeaderLines($name);
 
     /**
      * Create a new instance with the provided header, replacing any existing
@@ -111,12 +111,12 @@ interface MessageInterface
      * immutability of the message, and MUST return a new instance that has the
      * new and/or updated header and value.
      *
-     * @param string $header Header name
+     * @param string $name Case-insensitive header field name.
      * @param string|string[] $value Header value(s).
      * @return self
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withHeader($header, $value);
+    public function withHeader($name, $value);
 
     /**
      * Creates a new instance, with the specified header appended with the
@@ -130,12 +130,12 @@ interface MessageInterface
      * immutability of the message, and MUST return a new instance that has the
      * new header and/or value.
      *
-     * @param string $header Header name to add
+     * @param string $name Case-insensitive header field name to add.
      * @param string|string[] $value Header value(s).
      * @return self
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withAddedHeader($header, $value);
+    public function withAddedHeader($name, $value);
 
     /**
      * Creates a new instance, without the specified header.
@@ -146,10 +146,10 @@ interface MessageInterface
      * immutability of the message, and MUST return a new instance that removes
      * the named header.
      *
-     * @param string $header HTTP header to remove
+     * @param string $name Case-insensitive header field name to remove.
      * @return self
      */
-    public function withoutHeader($header);
+    public function withoutHeader($name);
 
     /**
      * Gets the body of the message.

--- a/src/ServerRequestInterface.php
+++ b/src/ServerRequestInterface.php
@@ -187,11 +187,11 @@ interface ServerRequestInterface extends RequestInterface
      * specifying a default value to return if the attribute is not found.
      *
      * @see getAttributes()
-     * @param string $attribute Attribute name.
+     * @param string $name The attribute name.
      * @param mixed $default Default value to return if the attribute does not exist.
      * @return mixed
      */
-    public function getAttribute($attribute, $default = null);
+    public function getAttribute($name, $default = null);
 
     /**
      * Create a new instance with the specified derived request attribute.
@@ -204,11 +204,11 @@ interface ServerRequestInterface extends RequestInterface
      * updated attribute.
      *
      * @see getAttributes()
-     * @param string $attribute The attribute name.
+     * @param string $name The attribute name.
      * @param mixed $value The value of the attribute.
      * @return self
      */
-    public function withAttribute($attribute, $value);
+    public function withAttribute($name, $value);
 
     /**
      * Create a new instance that removes the specified derived request
@@ -222,8 +222,8 @@ interface ServerRequestInterface extends RequestInterface
      * the attribute.
      *
      * @see getAttributes()
-     * @param string $attribute The attribute name.
+     * @param string $name The attribute name.
      * @return self
      */
-    public function withoutAttribute($attribute);
+    public function withoutAttribute($name);
 }

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -254,7 +254,7 @@ interface UriInterface
      *
      * - If a scheme is present, "://" MUST append the value.
      * - If the authority information is present, that value will be
-     *   contatenated.
+     *   concatenated.
      * - If a path is present, it MUST be prefixed by a "/" character.
      * - If a query string is present, it MUST be prefixed by a "?" character.
      * - If a URI fragment is present, it MUST be prefixed by a "#" character.


### PR DESCRIPTION
Changed the verbiage of header and attribute related method arguments to ```$name``` instead of ```$header``` or ```$attribute``` to improve on readability as otherwise the arguments might be seen as objects (e.g. ```$header``` could be misinterpreted as needing a specific implementation like ```AuthHeader``` instead of being a header field name string). See [issue 410](https://github.com/php-fig/fig-standards/issues/410).

In addition to the above some consistency changes for the docs and a small typo fix were made.