### PR TITLE
change wording since "/" is part of the path

### DIFF
--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psr\Http\Message;
 
 /**
@@ -255,7 +256,7 @@ interface UriInterface
      * - If a scheme is present, "://" MUST append the value.
      * - If the authority information is present, that value will be
      *   concatenated.
-     * - If a path is present, it MUST be prefixed by a "/" character.
+     * - If a path is present, it MUST start with a "/" character.
      * - If a query string is present, it MUST be prefixed by a "?" character.
      * - If a URI fragment is present, it MUST be prefixed by a "#" character.
      *


### PR DESCRIPTION
The starting slash is part of the path, so the term "prefix" does not fit here (in contrast to query string and fragment).

E.g. "?" is the prefix of the query string "foo=bar". But "/" is part of the path "/foo".