### PR TITLE
Detail Host header sources

### DIFF
--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -21,6 +21,22 @@ namespace Psr\Http\Message;
 interface RequestInterface extends MessageInterface
 {
     /**
+     * Extends MessageInterface::getHeader() to provide request-specific
+     * behavior.
+     *
+     * This method acts exactly like MessageInterface::getHeader(), with
+     * one behavioral change: if the Host header is requested, but has
+     * not been previously set, the method SHOULD attempt to pull the host
+     * segment of the composed URI, if present.
+     *
+     * @see MessageInterface::getHeader()
+     * @see UriInterface::getHost()
+     * @param string $name Case-insensitive header field name.
+     * @return string
+     */
+    public function getHeader($name);
+
+    /**
      * Retrieves the message's request target.
      *
      * Retrieves the message's request-target either as it will appear (for

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -21,12 +21,30 @@ namespace Psr\Http\Message;
 interface RequestInterface extends MessageInterface
 {
     /**
+     * Extends MessageInterface::getHeaders() to provide request-specific
+     * behavior.
+     *
+     * Retrieves all message headers.
+     *
+     * This method acts exactly like MessageInterface::getHeaders(), with one
+     * behavioral change: if the Host header has not been previously set, the
+     * method MUST attempt to pull the host segment of the composed URI, if
+     * present.
+     *
+     * @see MessageInterface::getHeaders()
+     * @see UriInterface::getHost()
+     * @return array Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be an array of strings.
+     */
+    public function getHeaders();
+
+    /**
      * Extends MessageInterface::getHeader() to provide request-specific
      * behavior.
      *
      * This method acts exactly like MessageInterface::getHeader(), with
      * one behavioral change: if the Host header is requested, but has
-     * not been previously set, the method SHOULD attempt to pull the host
+     * not been previously set, the method MUST attempt to pull the host
      * segment of the composed URI, if present.
      *
      * @see MessageInterface::getHeader()
@@ -35,6 +53,24 @@ interface RequestInterface extends MessageInterface
      * @return string
      */
     public function getHeader($name);
+
+    /**
+     * Extends MessageInterface::getHeaderLines() to provide request-specific
+     * behavior.
+     *
+     * Retrieves a header by the given case-insensitive name as an array of strings.
+     *
+     * This method acts exactly like MessageInterface::getHeaderLines(), with
+     * one behavioral change: if the Host header is requested, but has
+     * not been previously set, the method MUST attempt to pull the host
+     * segment of the composed URI, if present.
+     *
+     * @see MessageInterface::getHeaderLines()
+     * @see UriInterface::getHost()
+     * @param string $name Case-insensitive header field name.
+     * @return string[]
+     */
+    public function getHeaderLines($name);
 
     /**
      * Retrieves the message's request target.


### PR DESCRIPTION
Per the [related PR for fig-standards](php-fig/fig-standards#446), this PR
updates the `RequestInterface` to override the `getHeader()` method and indicate
that the Host header should be pulled from the composed URI if no value has been
previously set.