### PR TITLE
Added language to withPath() regarding percent encoding

### DIFF
--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -227,6 +227,10 @@ interface UriInterface
      * Additionally, the query string SHOULD be parseable by parse_str() in
      * order to be valid.
      *
+     * The implementation MUST percent encode reserved characters as
+     * specified in RFC 3986, Section 2, but MUST NOT double-encode any
+     * characters.
+     *
      * An empty query string value is equivalent to removing the query string.
      *
      * @param string $query The query string to use with the new instance.

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -205,6 +205,10 @@ interface UriInterface
      * The path MUST be prefixed with "/"; if not, the implementation MAY
      * provide the prefix itself.
      *
+     * The implementation MUST percent encode reserved characters as
+     * specified in RFC 3986, Section 2, but MUST NOT double-encode any
+     * characters.
+     *
      * An empty path value is equivalent to removing the path.
      *
      * @param string $path The path to use with the new instance.

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -205,7 +205,7 @@ interface UriInterface
      * The path MUST be prefixed with "/"; if not, the implementation MAY
      * provide the prefix itself.
      *
-     * The implementation MUST percent encode reserved characters as
+     * The implementation MUST percent-encode reserved characters as
      * specified in RFC 3986, Section 2, but MUST NOT double-encode any
      * characters.
      *
@@ -227,7 +227,7 @@ interface UriInterface
      * Additionally, the query string SHOULD be parseable by parse_str() in
      * order to be valid.
      *
-     * The implementation MUST percent encode reserved characters as
+     * The implementation MUST percent-encode reserved characters as
      * specified in RFC 3986, Section 2, but MUST NOT double-encode any
      * characters.
      *


### PR DESCRIPTION
Per RFC 3986, section 2, reserved characters must be percent encoded.
Additionally, the implementation must not double-encode.

See php-fig/fig-standards#449 for the corresponding specification change.