### PR TITLE
Sync with php-fig/fig-standards#460

### DIFF
--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -99,7 +99,7 @@ interface UriInterface
      * Retrieve the path segment of the URI.
      *
      * This method MUST return a string; if no path is present it MUST return
-     * an empty string.
+     * the string "/".
      *
      * @return string The path segment of the URI.
      */


### PR DESCRIPTION
Sync with php-fig/fig-standards#460 and clarify that an empty path
should be returned as "/".