### PR TITLE
Bring interfaces up-to-date with php-fig/fig-standards@b740164

### DIFF
--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -9,7 +9,7 @@ namespace Psr\Http\Message;
  *
  * Messages are considered immutable; all methods that might change state MUST
  * be implemented such that they retain the internal state of the current
- * message and return a new instance that contains the changed state.
+ * message and return an instance that contains the changed state.
  *
  * @link http://www.ietf.org/rfc/rfc7230.txt
  * @link http://www.ietf.org/rfc/rfc7231.txt
@@ -26,13 +26,13 @@ interface MessageInterface
     public function getProtocolVersion();
 
     /**
-     * Create a new instance with the specified HTTP protocol version.
+     * Return an instance with the specified HTTP protocol version.
      *
      * The version string MUST contain only the HTTP version number (e.g.,
      * "1.1", "1.0").
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * new protocol version.
      *
      * @param string $version HTTP protocol version
@@ -41,7 +41,7 @@ interface MessageInterface
     public function withProtocolVersion($version);
 
     /**
-     * Retrieves all message headers.
+     * Retrieves all message header values.
      *
      * The keys represent the header name as it will be sent over the wire, and
      * each value is an array of strings associated with the header.
@@ -62,7 +62,8 @@ interface MessageInterface
      * exact case in which headers were originally specified.
      *
      * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be an array of strings.
+     *     key MUST be a header name, and each value MUST be an array of strings
+     *     for that header.
      */
     public function getHeaders();
 
@@ -77,44 +78,52 @@ interface MessageInterface
     public function hasHeader($name);
 
     /**
-     * Retrieve a header by the given case-insensitive name, as a string.
+     * Retrieves a message header value by the given case-insensitive name.
+     *
+     * This method returns an array of all the header values of the given
+     * case-insensitive header name.
+     *
+     * If the header does not appear in the message, this method MUST return an
+     * empty array.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string[] An array of string values as provided for the given
+     *    header. If the header does not appear in the message, this method MUST
+     *    return an empty array.
+     */
+    public function getHeader($name);
+
+    /**
+     * Retrieves the line for a single header, with the header values as a
+     * comma-separated string.
      *
      * This method returns all of the header values of the given
      * case-insensitive header name as a string concatenated together using
      * a comma.
      *
      * NOTE: Not all header values may be appropriately represented using
-     * comma concatenation. For such headers, use getHeaderLines() instead
+     * comma concatenation. For such headers, use getHeader() instead
      * and supply your own delimiter when concatenating.
-     * 
-     * If the header did not appear in the message, this method should return
+     *
+     * If the header does not appear in the message, this method MUST return
      * a null value.
      *
      * @param string $name Case-insensitive header field name.
-     * @return string|null
+     * @return string|null A string of values as provided for the given header
+     *    concatenated together using a comma. If the header does not appear in
+     *    the message, this method MUST return a null value.
      */
-    public function getHeader($name);
+    public function getHeaderLine($name);
 
     /**
-     * Retrieves a header by the given case-insensitive name as an array of strings.
-     * 
-     * If the header did not appear in the message, this method should return an
-     * empty array.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @return string[]
-     */
-    public function getHeaderLines($name);
-
-    /**
-     * Create a new instance with the provided header, replacing any existing
+     * Return an instance with the provided header, replacing any existing
      * values of any headers with the same case-insensitive name.
      *
      * While header names are case-insensitive, the casing of the header will
      * be preserved by this function, and returned from getHeaders().
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * new and/or updated header and value.
      *
      * @param string $name Case-insensitive header field name.
@@ -125,7 +134,7 @@ interface MessageInterface
     public function withHeader($name, $value);
 
     /**
-     * Creates a new instance, with the specified header appended with the
+     * Return an instance with the specified header appended with the
      * given value.
      *
      * Existing values for the specified header will be maintained. The new
@@ -133,7 +142,7 @@ interface MessageInterface
      * exist previously, it will be added.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * new header and/or value.
      *
      * @param string $name Case-insensitive header field name to add.
@@ -144,12 +153,12 @@ interface MessageInterface
     public function withAddedHeader($name, $value);
 
     /**
-     * Creates a new instance, without the specified header.
+     * Return an instance without the specified header.
      *
      * Header resolution MUST be done without case-sensitivity.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that removes
+     * immutability of the message, and MUST return an instance that removes
      * the named header.
      *
      * @param string $name Case-insensitive header field name to remove.
@@ -160,22 +169,22 @@ interface MessageInterface
     /**
      * Gets the body of the message.
      *
-     * @return StreamableInterface Returns the body as a stream.
+     * @return StreamInterface Returns the body as a stream.
      */
     public function getBody();
 
     /**
-     * Create a new instance, with the specified message body.
+     * Return an instance with the specified message body.
      *
-     * The body MUST be a StreamableInterface object.
+     * The body MUST be a StreamInterface object.
      *
      * This method MUST be implemented in such a way as to retain the
      * immutability of the message, and MUST return a new instance that has the
      * new body stream.
      *
-     * @param StreamableInterface $body Body.
+     * @param StreamInterface $body Body.
      * @return self
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function withBody(StreamableInterface $body);
+    public function withBody(StreamInterface $body);
 }

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -16,7 +16,7 @@ namespace Psr\Http\Message;
  *
  * Requests are considered immutable; all methods that might change state MUST
  * be implemented such that they retain the internal state of the current
- * message and return a new instance that contains the changed state.
+ * message and return an instance that contains the changed state.
  */
 interface RequestInterface extends MessageInterface
 {
@@ -28,7 +28,7 @@ interface RequestInterface extends MessageInterface
      *
      * This method acts exactly like MessageInterface::getHeaders(), with one
      * behavioral change: if the Host header has not been previously set, the
-     * method MUST attempt to pull the host segment of the composed URI, if
+     * method MUST attempt to pull the host component of the composed URI, if
      * present.
      *
      * @see MessageInterface::getHeaders()
@@ -45,12 +45,14 @@ interface RequestInterface extends MessageInterface
      * This method acts exactly like MessageInterface::getHeader(), with
      * one behavioral change: if the Host header is requested, but has
      * not been previously set, the method MUST attempt to pull the host
-     * segment of the composed URI, if present.
+     * component of the composed URI, if present.
      *
      * @see MessageInterface::getHeader()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string
+     * @return string[] An array of string values as provided for the given
+     *    header. If the header does not appear in the message, this method MUST
+     *    return an empty array.
      */
     public function getHeader($name);
 
@@ -58,19 +60,23 @@ interface RequestInterface extends MessageInterface
      * Extends MessageInterface::getHeaderLines() to provide request-specific
      * behavior.
      *
-     * Retrieves a header by the given case-insensitive name as an array of strings.
+     * This method returns all of the header values of the given
+     * case-insensitive header name as a string concatenated together using
+     * a comma.
      *
      * This method acts exactly like MessageInterface::getHeaderLines(), with
      * one behavioral change: if the Host header is requested, but has
      * not been previously set, the method MUST attempt to pull the host
-     * segment of the composed URI, if present.
+     * component of the composed URI, if present.
      *
-     * @see MessageInterface::getHeaderLines()
+     * @see MessageInterface::getHeaderLine()
      * @see UriInterface::getHost()
      * @param string $name Case-insensitive header field name.
-     * @return string[]
+     * @return string|null A string of values as provided for the given header
+     *    concatenated together using a comma. If the header does not appear in
+     *    the message, this method MUST return a null value.
      */
-    public function getHeaderLines($name);
+    public function getHeaderLine($name);
 
     /**
      * Retrieves the message's request target.
@@ -91,7 +97,7 @@ interface RequestInterface extends MessageInterface
     public function getRequestTarget();
 
     /**
-     * Create a new instance with a specific request-target.
+     * Return an instance with the specific request-target.
      *
      * If the request needs a non-origin-form request-target — e.g., for
      * specifying an absolute-form, authority-form, or asterisk-form —
@@ -99,7 +105,7 @@ interface RequestInterface extends MessageInterface
      * request-target, verbatim.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * changed request target.
      *
      * @link http://tools.ietf.org/html/rfc7230#section-2.7 (for the various
@@ -117,14 +123,14 @@ interface RequestInterface extends MessageInterface
     public function getMethod();
 
     /**
-     * Create a new instance with the provided HTTP method.
+     * Return an instance with the provided HTTP method.
      *
      * While HTTP method names are typically all uppercase characters, HTTP
      * method names are case-sensitive and thus implementations SHOULD NOT
      * modify the given string.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * changed request method.
      *
      * @param string $method Case-insensitive method.
@@ -145,15 +151,29 @@ interface RequestInterface extends MessageInterface
     public function getUri();
 
     /**
-     * Create a new instance with the provided URI.
+     * Returns an instance with the provided URI.
+     *
+     * This method will update the Host header of the returned request by
+     * default if the URI contains a host component. If the URI does not
+     * contain a host component, any pre-existing Host header will be carried
+     * over to the returned request.
+     *
+     * You can opt-in to preserving the original state of the Host header by
+     * setting `$preserveHost` to `true`. When `$preserveHost` is set to
+     * `true`, the returned request will not update the Host header of the
+     * returned message -- even if the message contains no Host header. This
+     * means that a call to `getHeader('Host')` on the original request MUST
+     * equal the return value of a call to `getHeader('Host')` on the returned
+     * request.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * new UriInterface instance.
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param UriInterface $uri New request URI to use.
+     * @param bool $preserveHost Preserve the original state of the Host header.
      * @return self
      */
-    public function withUri(UriInterface $uri);
+    public function withUri(UriInterface $uri, $preserveHost = false);
 }

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -15,35 +15,35 @@ namespace Psr\Http\Message;
  *
  * Responses are considered immutable; all methods that might change state MUST
  * be implemented such that they retain the internal state of the current
- * message and return a new instance that contains the changed state.
+ * message and return an instance that contains the changed state.
  */
 interface ResponseInterface extends MessageInterface
 {
     /**
-     * Gets the response Status-Code.
+     * Gets the response status code.
      *
-     * The Status-Code is a 3-digit integer result code of the server's attempt
+     * The status code is a 3-digit integer result code of the server's attempt
      * to understand and satisfy the request.
      *
-     * @return integer Status code.
+     * @return int Status code.
      */
     public function getStatusCode();
 
     /**
-     * Create a new instance with the specified status code, and optionally
+     * Return an instance with the specified status code, and optionally
      * reason phrase, for the response.
      *
-     * If no Reason-Phrase is specified, implementations MAY choose to default
+     * If no reason phrase is specified, implementations MAY choose to default
      * to the RFC 7231 or IANA recommended reason phrase for the response's
-     * Status-Code.
+     * status code.
      *
      * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
+     * immutability of the message, and MUST return an instance that has the
      * updated status and reason phrase.
      *
      * @link http://tools.ietf.org/html/rfc7231#section-6
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @param integer $code The 3-digit integer result code to set.
+     * @param int $code The 3-digit integer result code to set.
      * @param null|string $reasonPhrase The reason phrase to use with the
      *     provided status code; if none is provided, implementations MAY
      *     use the defaults as suggested in the HTTP specification.
@@ -53,13 +53,14 @@ interface ResponseInterface extends MessageInterface
     public function withStatus($code, $reasonPhrase = null);
 
     /**
-     * Gets the response Reason-Phrase, a short textual description of the Status-Code.
+     * Gets the response reason phrase, a short textual description of the
+     * status code.
      *
-     * Because a Reason-Phrase is not a required element in a response
-     * Status-Line, the Reason-Phrase value MAY be null. Implementations MAY
+     * Because a reason phrase is not a required element in a response
+     * status line, the reason phrase value MAY be null. Implementations MAY
      * choose to return the default RFC 7231 recommended reason phrase (or those
      * listed in the IANA HTTP Status Code Registry) for the response's
-     * Status-Code.
+     * status code.
      *
      * @link http://tools.ietf.org/html/rfc7231#section-6
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml

--- a/src/StreamInterface.php
+++ b/src/StreamInterface.php
@@ -3,13 +3,13 @@
 namespace Psr\Http\Message;
 
 /**
- * Describes streamable message body content.
+ * Describes a data stream.
  *
  * Typically, an instance will wrap a PHP stream; this interface provides
  * a wrapper around the most common operations, including serialization of
  * the entire stream to a string.
  */
-interface StreamableInterface
+interface StreamInterface
 {
     /**
      * Reads all data from the stream into a string, from the beginning to end.
@@ -19,6 +19,10 @@ interface StreamableInterface
      *
      * Warning: This could attempt to load a large amount of data into memory.
      *
+     * This method MUST NOT raise an exception in order to conform with PHP's
+     * string casting operations.
+     *
+     * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
      * @return string
      */
     public function __toString();
@@ -49,7 +53,8 @@ interface StreamableInterface
     /**
      * Returns the current position of the file read/write pointer
      *
-     * @return int|bool Position of the file pointer or false on error.
+     * @return int Position of the file pointer
+     * @throws \RuntimeException on error.
      */
     public function tell();
 
@@ -77,20 +82,19 @@ interface StreamableInterface
      *     PHP $whence values for `fseek()`.  SEEK_SET: Set position equal to
      *     offset bytes SEEK_CUR: Set position to current location plus offset
      *     SEEK_END: Set position to end-of-stream plus offset.
-     * @return bool Returns TRUE on success or FALSE on failure.
+     * @throws \RuntimeException on failure.
      */
     public function seek($offset, $whence = SEEK_SET);
 
     /**
      * Seek to the beginning of the stream.
      *
-     * If the stream is not seekable, this method will return FALSE, indicating
-     * failure; otherwise, it will perform a seek(0), and return the status of
-     * that operation.
+     * If the stream is not seekable, this method will raise an exception;
+     * otherwise, it will perform a seek(0).
      *
      * @see seek()
      * @link http://www.php.net/manual/en/function.fseek.php
-     * @return bool Returns TRUE on success or FALSE on failure.
+     * @throws \RuntimeException on failure.
      */
     public function rewind();
 
@@ -105,8 +109,8 @@ interface StreamableInterface
      * Write data to the stream.
      *
      * @param string $string The string that is to be written.
-     * @return int|bool Returns the number of bytes written to the stream on
-     *     success or FALSE on failure.
+     * @return int Returns the number of bytes written to the stream.
+     * @throws \RuntimeException on failure.
      */
     public function write($string);
 
@@ -123,8 +127,9 @@ interface StreamableInterface
      * @param int $length Read up to $length bytes from the object and return
      *     them. Fewer than $length bytes may be returned if underlying stream
      *     call returns fewer bytes.
-     * @return string|false Returns the data read from the stream, false if
-     *     unable to read or if an error occurs.
+     * @return string Returns the data read from the stream, or an empty string
+     *     if no bytes are available.
+     * @throws \RuntimeException if an error occurs.
      */
     public function read($length);
 
@@ -132,6 +137,8 @@ interface StreamableInterface
      * Returns the remaining contents in a string
      *
      * @return string
+     * @throws \RuntimeException if unable to read or an error occurs while
+     *     reading.
      */
     public function getContents();
 

--- a/src/UploadedFileInterface.php
+++ b/src/UploadedFileInterface.php
@@ -1,0 +1,115 @@
+<?php
+namespace Psr\Http\Message;
+
+/**
+ * Value object representing a file uploaded through an HTTP request.
+ *
+ * Instances of this interface are considered immutable; all methods that
+ * might change state MUST be implemented such that they retain the internal
+ * state of the current instance and return an instance that contains the
+ * changed state.
+ */
+interface UploadedFileInterface
+{
+    /**
+     * Retrieve a stream representing the uploaded file.
+     *
+     * This method MUST return a StreamInterface instance, representing the
+     * uploaded file. The purpose of this method is to allow utilizing native PHP
+     * stream functionality to manipulate the file upload, such as
+     * stream_copy_to_stream() (though the result will need to be decorated in a
+     * native PHP stream wrapper to work with such functions).
+     *
+     * If the move() method has been called previously, this method MUST raise
+     * an exception.
+     *
+     * @return StreamInterface Stream representation of the uploaded file.
+     * @throws \RuntimeException in cases when no stream is available or can be
+     *     created.
+     */
+    public function getStream();
+
+    /**
+     * Move the uploaded file to a new location.
+     *
+     * Use this method as an alternative to move_uploaded_file(). This method is
+     * guaranteed to work in both SAPI and non-SAPI environments.
+     * Implementations must determine which environment they are in, and use the
+     * appropriate method (move_uploaded_file(), rename(), or a stream
+     * operation) to perform the operation.
+     *
+     * The original file or stream MUST be removed on completion.
+     *
+     * If this method is called more than once, any subsequent calls MUST raise
+     * an exception.
+     *
+     * When used in an SAPI environment where $_FILES is populated, when writing
+     * files via move(), is_uploaded_file() and move_uploaded_file() SHOULD be
+     * use to ensure permissions and upload status are verified correctly.
+     *
+     * @see http://php.net/is_uploaded_file
+     * @see http://php.net/move_uploaded_file
+     * @param string $path Path to which to move the uploaded file.
+     * @throws \InvalidArgumentException if the $path specified is invalid.
+     * @throws \RuntimeException on any error during the move operation, or on
+     *     the second or subsequent call to the method.
+     */
+    public function move($path);
+    
+    /**
+     * Retrieve the file size.
+     *
+     * Implementations SHOULD return the value stored in the "size" key of
+     * the file in the $_FILES array if available, as PHP calculates this based
+     * on the actual size transmitted.
+     *
+     * @return int|null The file size in bytes or null if unknown.
+     */
+    public function getSize();
+    
+    /**
+     * Retrieve the error associated with the uploaded file.
+     *
+     * The return value MUST be one of PHP's UPLOAD_ERR_XXX constants.
+     *
+     * If the file was uploaded successfully, this method MUST return
+     * UPLOAD_ERR_OK.
+     *
+     * Implementations SHOULD return the value stored in the "error" key of
+     * the file in the $_FILES array.
+     *
+     * @see http://php.net/manual/en/features.file-upload.errors.php
+     * @return int One of PHP's UPLOAD_ERR_XXX constants.
+     */
+    public function getError();
+    
+    /**
+     * Retrieve the filename sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious filename with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "name" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The filename sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientFilename();
+    
+    /**
+     * Retrieve the media type sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious media type with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "type" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The media type sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientMediaType();
+}

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -2,14 +2,17 @@
 namespace Psr\Http\Message;
 
 /**
- * Value object representing a URI for use in HTTP requests.
+ * Value object representing a URI.
  *
- * This interface is meant to represent only URIs for use with HTTP requests,
- * and is not intended as a general-purpose URI implementation.
+ * This interface is meant to represent URIs according to RFC 3986 and to
+ * provide methods for most common operations. Additional functionality for
+ * working with URIs can be provided on top of the interface or externally.
+ * Its primary use is for HTTP requests, but may also be used in other
+ * contexts.
  *
  * Instances of this interface are considered immutable; all methods that
  * might change state MUST be implemented such that they retain the internal
- * state of the current instance and return a new instance that contains the
+ * state of the current instance and return an instance that contains the
  * changed state.
  *
  * Typically the Host header will be also be present in the request message.
@@ -21,23 +24,28 @@ namespace Psr\Http\Message;
 interface UriInterface
 {
     /**
-     * Retrieve the URI scheme.
-     *
-     * Implementations SHOULD restrict values to "http", "https", or an empty
-     * string but MAY accommodate other schemes if required.
+     * Retrieve the scheme component of the URI.
      *
      * If no scheme is present, this method MUST return an empty string.
      *
-     * The string returned MUST omit the trailing "://" delimiter if present.
+     * The value returned MUST be normalized to lowercase, per RFC 3986
+     * Section 3.1.
      *
-     * @return string The scheme of the URI.
+     * The trailing ":" character is not part of the scheme and MUST NOT be
+     * added.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-3.1
+     * @return string The URI scheme.
      */
     public function getScheme();
 
     /**
-     * Retrieve the authority portion of the URI.
+     * Retrieve the authority component of the URI.
      *
-     * The authority portion of the URI is:
+     * If no authority information is present, this method MUST return an empty
+     * string.
+     *
+     * The authority syntax of the URI is:
      *
      * <pre>
      * [user-info@]host[:port]
@@ -46,40 +54,43 @@ interface UriInterface
      * If the port component is not set or is the standard port for the current
      * scheme, it SHOULD NOT be included.
      *
-     * This method MUST return an empty string if no authority information is
-     * present.
-     *
-     * @return string Authority portion of the URI, in "[user-info@]host[:port]"
-     *     format.
+     * @see https://tools.ietf.org/html/rfc3986#section-3.2
+     * @return string The URI authority, in "[user-info@]host[:port]" format.
      */
     public function getAuthority();
 
     /**
-     * Retrieve the user information portion of the URI, if present.
+     * Retrieve the user information component of the URI.
+     *
+     * If no user information is present, this method MUST return an empty
+     * string.
      *
      * If a user is present in the URI, this will return that value;
      * additionally, if the password is also present, it will be appended to the
      * user value, with a colon (":") separating the values.
      *
-     * Implementations MUST NOT return the "@" suffix when returning this value.
+     * The trailing "@" character is not part of the user information and MUST
+     * NOT be added.
      *
-     * @return string User information portion of the URI, if present, in
-     *     "username[:password]" format.
+     * @return string The URI user information, in "username[:password]" format.
      */
     public function getUserInfo();
 
     /**
-     * Retrieve the host segment of the URI.
+     * Retrieve the host component of the URI.
      *
-     * This method MUST return a string; if no host segment is present, an
-     * empty string MUST be returned.
+     * If no host is present, this method MUST return an empty string.
      *
-     * @return string Host segment of the URI.
+     * The value returned MUST be normalized to lowercase, per RFC 3986
+     * Section 3.2.2.
+     *
+     * @see http://tools.ietf.org/html/rfc3986#section-3.2.2
+     * @return string The URI host.
      */
     public function getHost();
 
     /**
-     * Retrieve the port segment of the URI.
+     * Retrieve the port component of the URI.
      *
      * If a port is present, and it is non-standard for the current scheme,
      * this method MUST return it as an integer. If the port is the standard port
@@ -91,53 +102,85 @@ interface UriInterface
      * If no port is present, but a scheme is present, this method MAY return
      * the standard port for that scheme, but SHOULD return null.
      *
-     * @return null|int The port for the URI.
+     * @return null|int The URI port.
      */
     public function getPort();
 
     /**
-     * Retrieve the path segment of the URI.
+     * Retrieve the path component of the URI.
      *
-     * This method MUST return a string; if no path is present it MUST return
-     * the string "/".
+     * The path can either be empty or absolute (starting with a slash) or
+     * rootless (not starting with a slash). Implementations MUST support all
+     * three syntaxes.
      *
-     * @return string The path segment of the URI.
+     * Normally, the empty path "" and absolute path "/" are considered equal as
+     * defined in RFC 7230 Section 2.7.3. But this method MUST NOT automatically
+     * do this normalization because in contexts with a trimmed base path, e.g.
+     * the front controller, this difference becomes significant. It's the task
+     * of the user to handle both "" and "/".
+     *
+     * The value returned MUST be percent-encoded, but MUST NOT double-encode
+     * any characters. To determine what characters to encode, please refer to
+     * RFC 3986, Sections 2 and 3.3.
+     *
+     * As an example, if the value should include a slash ("/") not intended as
+     * delimiter between path segments, that value MUST be passed in encoded
+     * form (e.g., "%2F") to the instance.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.3
+     * @return string The URI path.
      */
     public function getPath();
 
     /**
      * Retrieve the query string of the URI.
      *
-     * This method MUST return a string; if no query string is present, it MUST
-     * return an empty string.
+     * If no query string is present, this method MUST return an empty string.
      *
-     * The string returned MUST omit the leading "?" character.
+     * The leading "?" character is not part of the query and MUST NOT be
+     * added.
      *
+     * The value returned MUST be percent-encoded, but MUST NOT double-encode
+     * any characters. To determine what characters to encode, please refer to
+     * RFC 3986, Sections 2 and 3.4.
+     *
+     * As an example, if a value in a key/value pair of the query string should
+     * include an ampersand ("&") not intended as a delimiter between values,
+     * that value MUST be passed in encoded form (e.g., "%26") to the instance.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.4
      * @return string The URI query string.
      */
     public function getQuery();
 
     /**
-     * Retrieve the fragment segment of the URI.
+     * Retrieve the fragment component of the URI.
      *
-     * This method MUST return a string; if no fragment is present, it MUST
-     * return an empty string.
+     * If no fragment is present, this method MUST return an empty string.
      *
-     * The string returned MUST omit the leading "#" character.
+     * The leading "#" character is not part of the fragment and MUST NOT be
+     * added.
      *
+     * The value returned MUST be percent-encoded, but MUST NOT double-encode
+     * any characters. To determine what characters to encode, please refer to
+     * RFC 3986, Sections 2 and 3.5.
+     *
+     * @see https://tools.ietf.org/html/rfc3986#section-2
+     * @see https://tools.ietf.org/html/rfc3986#section-3.5
      * @return string The URI fragment.
      */
     public function getFragment();
 
     /**
-     * Create a new instance with the specified scheme.
+     * Return an instance with the specified scheme.
      *
      * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified scheme. If the scheme
-     * provided includes the "://" delimiter, it MUST be removed.
+     * an instance that contains the specified scheme.
      *
-     * Implementations SHOULD restrict values to "http", "https", or an empty
-     * string but MAY accommodate other schemes if required.
+     * Implementations MUST support the schemes "http" and "https" case
+     * insensitively, and MAY accommodate other schemes if required.
      *
      * An empty scheme is equivalent to removing the scheme.
      *
@@ -148,40 +191,40 @@ interface UriInterface
     public function withScheme($scheme);
 
     /**
-     * Create a new instance with the specified user information.
+     * Return an instance with the specified user information.
      *
      * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified user information.
+     * an instance that contains the specified user information.
      *
      * Password is optional, but the user information MUST include the
      * user; an empty string for the user is equivalent to removing user
      * information.
      *
-     * @param string $user User name to use for authority.
-     * @param null|string $password Password associated with $user.
+     * @param string $user The user name to use for authority.
+     * @param null|string $password The password associated with $user.
      * @return self A new instance with the specified user information.
      */
     public function withUserInfo($user, $password = null);
 
     /**
-     * Create a new instance with the specified host.
+     * Return an instance with the specified host.
      *
      * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified host.
+     * an instance that contains the specified host.
      *
      * An empty host value is equivalent to removing the host.
      *
-     * @param string $host Hostname to use with the new instance.
+     * @param string $host The hostname to use with the new instance.
      * @return self A new instance with the specified host.
      * @throws \InvalidArgumentException for invalid hostnames.
      */
     public function withHost($host);
 
     /**
-     * Create a new instance with the specified port.
+     * Return an instance with the specified port.
      *
      * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified port.
+     * an instance that contains the specified port.
      *
      * Implementations MUST raise an exception for ports outside the
      * established TCP and UDP port ranges.
@@ -189,7 +232,7 @@ interface UriInterface
      * A null value provided for the port is equivalent to removing the port
      * information.
      *
-     * @param null|int $port Port to use with the new instance; a null value
+     * @param null|int $port The port to use with the new instance; a null value
      *     removes the port information.
      * @return self A new instance with the specified port.
      * @throws \InvalidArgumentException for invalid ports.
@@ -197,19 +240,17 @@ interface UriInterface
     public function withPort($port);
 
     /**
-     * Create a new instance with the specified path.
+     * Return an instance with the specified path.
      *
      * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified path.
+     * an instance that contains the specified path.
      *
-     * The path MUST be prefixed with "/"; if not, the implementation MAY
-     * provide the prefix itself.
+     * The path can either be empty or absolute (starting with a slash) or
+     * rootless (not starting with a slash). Implementations MUST support all
+     * three syntaxes.
      *
-     * The implementation MUST percent-encode reserved characters as
-     * specified in RFC 3986, Section 2, but MUST NOT double-encode any
-     * characters.
-     *
-     * An empty path value is equivalent to removing the path.
+     * Users can provide both encoded and decoded path characters.
+     * Implementations ensure the correct encoding as outlined in getPath().
      *
      * @param string $path The path to use with the new instance.
      * @return self A new instance with the specified path.
@@ -218,18 +259,13 @@ interface UriInterface
     public function withPath($path);
 
     /**
-     * Create a new instance with the specified query string.
+     * Return an instance with the specified query string.
      *
      * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified query string.
+     * an instance that contains the specified query string.
      *
-     * If the query string is prefixed by "?", that character MUST be removed.
-     * Additionally, the query string SHOULD be parseable by parse_str() in
-     * order to be valid.
-     *
-     * The implementation MUST percent-encode reserved characters as
-     * specified in RFC 3986, Section 2, but MUST NOT double-encode any
-     * characters.
+     * Users can provide both encoded and decoded query characters.
+     * Implementations ensure the correct encoding as outlined in getQuery().
      *
      * An empty query string value is equivalent to removing the query string.
      *
@@ -240,33 +276,42 @@ interface UriInterface
     public function withQuery($query);
 
     /**
-     * Create a new instance with the specified URI fragment.
+     * Return an instance with the specified URI fragment.
      *
      * This method MUST retain the state of the current instance, and return
-     * a new instance that contains the specified URI fragment.
+     * an instance that contains the specified URI fragment.
      *
-     * If the fragment is prefixed by "#", that character MUST be removed.
+     * Users can provide both encoded and decoded fragment characters.
+     * Implementations ensure the correct encoding as outlined in getFragment().
      *
      * An empty fragment value is equivalent to removing the fragment.
      *
-     * @param string $fragment The URI fragment to use with the new instance.
-     * @return self A new instance with the specified URI fragment.
+     * @param string $fragment The fragment to use with the new instance.
+     * @return self A new instance with the specified fragment.
      */
     public function withFragment($fragment);
 
     /**
-     * Return the string representation of the URI.
+     * Return the string representation as a URI reference.
      *
-     * Concatenates the various segments of the URI, using the appropriate
-     * delimiters:
+     * Depending on which components of the URI are present, the resulting
+     * string is either a full URI or relative reference according to RFC 3985,
+     * Section 4.1. The method concatenates the various components of the URI,
+     * using the appropriate delimiters:
      *
-     * - If a scheme is present, "://" MUST append the value.
-     * - If the authority information is present, that value will be
-     *   concatenated.
-     * - If a path is present, it MUST be prefixed by a "/" character.
-     * - If a query string is present, it MUST be prefixed by a "?" character.
-     * - If a URI fragment is present, it MUST be prefixed by a "#" character.
+     * - If a scheme is present, it MUST be suffixed by ":".
+     * - If an authority is present, it MUST be prefixed by "//".
+     * - The path can be concatenated without delimiters. But there are two
+     *   cases where the path has to be adjusted to make the URI reference
+     *   valid as PHP does not allow to throw an exception in __toString():
+     *     - If the path is rootless and an authority is present, the path MUST
+     *       be prefixed by "/".
+     *     - If the path is starting with more than one "/" and no authority is
+     *       present, the starting slashes MUST be reduced to one.
+     * - If a query is present, it MUST be prefixed by "?".
+     * - If a fragment is present, it MUST be prefixed by "#".
      *
+     * @see http://tools.ietf.org/html/rfc3986#section-4.1
      * @return string
      */
     public function __toString();


### PR DESCRIPTION
This patch brings the interfaces up-to-date with php-fig/fig-standards@b740164

In particular:

- `StreamableInterface` was renamed to `StreamInterface`; typehints were updated accordingly.
- `ServerRequestInterface::*FileParams()` were renamed to `*UploadedFiles()`. They now expect and return array trees of a new interface, `UploadedFileInterface`.
- `UploadedFileInterface` was added to provide compatibility between SAPI and non-SAPI environments with regards to handling upload files.
- A number of clarifications were made on `UriInterface` with regards to URI component delimiters.