### PR TITLE
Sync with php-fig/fig-standards#518

### DIFF
--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -146,7 +146,7 @@ interface RequestInterface extends MessageInterface
      *
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @return UriInterface Returns a UriInterface instance
-     *     representing the URI of the request, if any.
+     *     representing the URI of the request.
      */
     public function getUri();
 


### PR DESCRIPTION
This syncs with php-fig/fig-standards#518

After merge, please tag 0.10.1, with the message "Clarify RequestInterface::getUri() return value".