### PR TITLE
Fix: Add missing parameter name to docblock

### DIFF
--- a/src/ServerRequestInterface.php
+++ b/src/ServerRequestInterface.php
@@ -143,7 +143,7 @@ interface ServerRequestInterface extends RequestInterface
      * immutability of the message, and MUST return an instance that has the
      * updated body parameters.
      *
-     * @param array An array tree of UploadedFileInterface instances.
+     * @param array $uploadedFiles An array tree of UploadedFileInterface instances.
      * @return self
      * @throws \InvalidArgumentException if an invalid structure is provided.
      */


### PR DESCRIPTION
This PR

* [x] adds the missing parameter name `$uploadedFiles` to the docblock of `ServerRequestInterface::withUploadedFiles()`