### PR TITLE
Remove dev branch alias from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,5 @@
         "psr-4": {
             "Psr\\Http\\Message\\": "src/"
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0.x-dev"
-        }
     }
 }


### PR DESCRIPTION
Now that PSR-7 is officially a thing ([there was cake](https://twitter.com/ramsey/status/601582764526333953)), we don't need the dev branch alias anymore. :)