### PR TITLE
Mutable version of interfaces

### DIFF
--- a/src/MutableMessageInterface.php
+++ b/src/MutableMessageInterface.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * This interface extends standard MessageInterface by adding mutability.
+ */
+interface MutableMessageInterface extends MessageInterface
+{
+
+    /**
+     * Modifies current instance by setting specified HTTP protocol version.
+     *
+     * The version string MUST contain only the HTTP version number (e.g.,
+     * "1.1", "1.0").
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param string $version HTTP protocol version
+     * @return self
+     */
+    public function setProtocolVersion($version);
+
+    /**
+     * Modifies current instance by replacing given header with new value.
+     *
+     * While header names are case-insensitive, the casing of the header will
+     * be preserved by this function, and returned from getHeaders().
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @param string|string[] $value Header value(s).
+     * @return self
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function setHeader($name, $value);
+
+    /**
+     * Modifies current instance by adding header with given value to already excising one.
+     *
+     * Existing values for the specified header will be maintained. The new
+     * value(s) will be appended to the existing list. If the header did not
+     * exist previously, it will be added.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param string $name Case-insensitive header field name to add.
+     * @param string|string[] $value Header value(s).
+     * @return self
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function addHeader($name, $value);
+
+    /**
+     * Modifies current instance by removing specified header.
+     *
+     * Header resolution MUST be done without case-sensitivity.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param string $name Case-insensitive header field name to remove.
+     * @return self
+     */
+    public function removeHeader($name);
+
+    /**
+     * Modifies current instance by replacing body with specified one.
+     *
+     * The body MUST be a StreamInterface object.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param StreamInterface $body Body.
+     * @return self
+     * @throws \InvalidArgumentException When the body is not valid.
+     */
+    public function setBody(StreamInterface $body);
+}

--- a/src/MutableRequestInterface.php
+++ b/src/MutableRequestInterface.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * This interface extends standard RequestInterface by adding mutability.
+ */
+interface MutableRequestInterface extends RequestInterface
+{
+    /**
+     * Modifies current instance by setting specified request-target.
+     *
+     * If the request needs a non-origin-form request-target — e.g., for
+     * specifying an absolute-form, authority-form, or asterisk-form —
+     * this method may be used to create an instance with the specified
+     * request-target, verbatim.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @link http://tools.ietf.org/html/rfc7230#section-2.7 (for the various
+     *     request-target forms allowed in request messages)
+     * @param mixed $requestTarget
+     * @return self
+     */
+    public function setRequestTarget($requestTarget);
+
+    /**
+     * Modifies current instance by setting specified HTTP method.
+     *
+     * While HTTP method names are typically all uppercase characters, HTTP
+     * method names are case-sensitive and thus implementations SHOULD NOT
+     * modify the given string.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param string $method Case-sensitive method.
+     * @return self
+     * @throws \InvalidArgumentException for invalid HTTP methods.
+     */
+    public function setMethod($method);
+
+    /**
+     * Modifies current instance by setting specified URI.
+     *
+     * This method MUST update the Host header of the returned request by
+     * default if the URI contains a host component. If the URI does not
+     * contain a host component, any pre-existing Host header MUST be carried
+     * over to the returned request.
+     *
+     * You can opt-in to preserving the original state of the Host header by
+     * setting `$preserveHost` to `true`. When `$preserveHost` is set to
+     * `true`, this method interacts with the Host header in the following ways:
+     *
+     * - If the the Host header is missing or empty, and the new URI contains
+     *   a host component, this method MUST update the Host header in the returned
+     *   request.
+     * - If the Host header is missing or empty, and the new URI does not contain a
+     *   host component, this method MUST NOT update the Host header in the returned
+     *   request.
+     * - If a Host header is present and non-empty, this method MUST NOT update
+     *   the Host header in the returned request.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-4.3
+     * @param UriInterface $uri New request URI to use.
+     * @param bool $preserveHost Preserve the original state of the Host header.
+     * @return self
+     */
+    public function setUri(UriInterface $uri, $preserveHost = false);
+}

--- a/src/MutableResponseInterface.php
+++ b/src/MutableResponseInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * Representation of an outgoing, server-side response.
+ * This interface extends standard ResponseInterface by adding mutability.
+ */
+interface MutableResponseInterface extends MessageInterface
+{
+    /**
+     * Sets status code and, optionally, reason phrase on current instance.
+     *
+     * If no reason phrase is specified, implementations MAY choose to default
+     * to the RFC 7231 or IANA recommended reason phrase for the response's
+     * status code.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @link http://tools.ietf.org/html/rfc7231#section-6
+     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+     * @param int $code The 3-digit integer result code to set.
+     * @param string $reasonPhrase The reason phrase to use with the
+     *     provided status code; if none is provided, implementations MAY
+     *     use the defaults as suggested in the HTTP specification.
+     * @return self
+     * @throws \InvalidArgumentException For invalid status code arguments.
+     */
+    public function setStatus($code, $reasonPhrase = '');
+}

--- a/src/MutableServerRequestInterface.php
+++ b/src/MutableServerRequestInterface.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * Representation of an incoming, server-side HTTP request.
+ * This interface extends standard ServerRequestInterface by adding mutability.
+ */
+interface MutableServerRequestInterface extends ServerRequestInterface
+{
+    /**
+     * Modifies current instance by setting specified cookies.
+     *
+     * The data IS NOT REQUIRED to come from the $_COOKIE superglobal, but MUST
+     * be compatible with the structure of $_COOKIE. Typically, this data will
+     * be injected at instantiation.
+     *
+     * This method MUST NOT update the related Cookie header of the request
+     * instance, nor related values in the server params.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param array $cookies Array of key/value pairs representing cookies.
+     * @return self
+     */
+    public function setCookieParams(array $cookies);
+
+    /**
+     * Modifies current instance by setting specified query string arguments.
+     *
+     * These values SHOULD remain immutable over the course of the incoming
+     * request. They MAY be injected during instantiation, such as from PHP's
+     * $_GET superglobal, or MAY be derived from some other value such as the
+     * URI. In cases where the arguments are parsed from the URI, the data
+     * MUST be compatible with what PHP's parse_str() would return for
+     * purposes of how duplicate query parameters are handled, and how nested
+     * sets are handled.
+     *
+     * Setting query string arguments MUST NOT change the URI stored by the
+     * request, nor the values in the server params.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param array $query Array of query string arguments, typically from
+     *     $_GET.
+     * @return self
+     */
+    public function setQueryParams(array $query);
+
+    /**
+     * Modifies current instance by setting specified uploaded files.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param array An array tree of UploadedFileInterface instances.
+     * @return self
+     * @throws \InvalidArgumentException if an invalid structure is provided.
+     */
+    public function setUploadedFiles(array $uploadedFiles);
+
+    /**
+     * Modifies current instance by setting specified body parameters.
+     *
+     * These MAY be injected during instantiation.
+     *
+     * If the request Content-Type is either application/x-www-form-urlencoded
+     * or multipart/form-data, and the request method is POST, use this method
+     * ONLY to inject the contents of $_POST.
+     *
+     * The data IS NOT REQUIRED to come from $_POST, but MUST be the results of
+     * deserializing the request body content. Deserialization/parsing returns
+     * structured data, and, as such, this method ONLY accepts arrays or objects,
+     * or a null value if nothing was available to parse.
+     *
+     * As an example, if content negotiation determines that the request data
+     * is a JSON payload, this method could be used to create a request
+     * instance with the deserialized parameters.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @param null|array|object $data The deserialized body data. This will
+     *     typically be in an array or object.
+     * @return self
+     * @throws \InvalidArgumentException if an unsupported argument type is
+     *     provided.
+     */
+    public function setParsedBody($data);
+
+    /**
+     * Modifies current instance by setting specified derived request attribute.
+     *
+     * This method allows setting a single derived request attribute as
+     * described in getAttributes().
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @see getAttributes()
+     * @param string $name The attribute name.
+     * @param mixed $value The value of the attribute.
+     * @return self
+     */
+    public function setAttribute($name, $value);
+
+    /**
+     * Modifies current instance by removing specified derived request attribute.
+     *
+     * This method allows removing a single derived request attribute as
+     * described in getAttributes().
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * @see getAttributes()
+     * @param string $name The attribute name.
+     * @return self
+     */
+    public function removeAttribute($name);
+}

--- a/src/MutableUriInterface.php
+++ b/src/MutableUriInterface.php
@@ -1,0 +1,131 @@
+<?php
+namespace Psr\Http\Message;
+
+/**
+ * Value object representing a URI.
+ * This interface extends standard ServerRequestInterface by adding mutability.
+ */
+interface MutableUriInterface extends UriInterface
+{
+    /**
+     * Modifies current instance by setting specified scheme.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * Implementations MUST support the schemes "http" and "https" case
+     * insensitively, and MAY accommodate other schemes if required.
+     *
+     * An empty scheme is equivalent to removing the scheme.
+     *
+     * @param string $scheme The scheme to set on current instance.
+     * @return self Current instance.
+     * @throws \InvalidArgumentException for invalid or unsupported schemes.
+     */
+    public function setScheme($scheme);
+
+    /**
+     * Modifies current instance by setting specified user information.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * Password is optional, but the user information MUST include the
+     * user; an empty string for the user is equivalent to removing user
+     * information.
+     *
+     * @param string $user The user name to use for authority.
+     * @param null|string $password The password associated with $user.
+     * @return self Current instance.
+     */
+    public function setUserInfo($user, $password = null);
+
+    /**
+     * Modifies current instance by setting specified host.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * An empty host value is equivalent to removing the host.
+     *
+     * @param string $host The hostname to set on current instance.
+     * @return self Current instance.
+     * @throws \InvalidArgumentException for invalid hostnames.
+     */
+    public function setHost($host);
+
+    /**
+     * Modifies current instance by setting specified port.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * Implementations MUST raise an exception for ports outside the
+     * established TCP and UDP port ranges.
+     *
+     * A null value provided for the port is equivalent to removing the port
+     * information.
+     *
+     * @param null|int $port The port to set on current instance; a null value removes the port information.
+     * @return self Current instance.
+     * @throws \InvalidArgumentException for invalid ports.
+     */
+    public function setPort($port);
+
+    /**
+     * Modifies current instance by setting specified path.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * The path can either be empty or absolute (starting with a slash) or
+     * rootless (not starting with a slash). Implementations MUST support all
+     * three syntaxes.
+     *
+     * If the path is intended to be domain-relative rather than path relative then
+     * it must begin with a slash ("/"). Paths not starting with a slash ("/")
+     * are assumed to be relative to some base path known to the application or
+     * consumer.
+     *
+     * Users can provide both encoded and decoded path characters.
+     * Implementations ensure the correct encoding as outlined in getPath().
+     *
+     * @param string $path The path to set on current instance.
+     * @return self Current instance.
+     * @throws \InvalidArgumentException for invalid paths.
+     */
+    public function setPath($path);
+
+    /**
+     * Modifies current instance by setting specified query string.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * Users can provide both encoded and decoded query characters.
+     * Implementations ensure the correct encoding as outlined in getQuery().
+     *
+     * An empty query string value is equivalent to removing the query string.
+     *
+     * @param string $query The query string to set on current instance.
+     * @return self Current instance.
+     * @throws \InvalidArgumentException for invalid query strings.
+     */
+    public function setQuery($query);
+
+    /**
+     * RModifies current instance by setting specified URI fragment.
+     *
+     * This method MUST be implemented in such a way as to modify current
+     * instance of object, and MUST return the same instance that has been called.
+     *
+     * Users can provide both encoded and decoded fragment characters.
+     * Implementations ensure the correct encoding as outlined in getFragment().
+     *
+     * An empty fragment value is equivalent to removing the fragment.
+     *
+     * @param string $fragment The fragment to set on current instance.
+     * @return self Current instance.
+     */
+    public function setFragment($fragment);
+}


### PR DESCRIPTION
I know we need a standard proposal to accept such change, but I don't feel competent enough to produce such document.
I added mutable interfaces for http-messages. They extends current immutable ones, so it's 100% BC.

Discussion about the problem inside issue https://github.com/php-fig/http-message/issues/53.