### PR TITLE
RequestMethodInterface 

### DIFF
--- a/src/RequestMethodInterface.php
+++ b/src/RequestMethodInterface.php
@@ -1,0 +1,18 @@
+<?php
+namespace Psr\Http\Message;
+
+/**
+ * The interface defines constants request method
+ */
+interface RequestMethodInterface {
+    const METHOD_HEAD = 'HEAD';
+    const METHOD_GET = 'GET';
+    const METHOD_POST = 'POST';
+    const METHOD_PUT = 'PUT';
+    const METHOD_PATCH = 'PATCH';
+    const METHOD_DELETE = 'DELETE';
+    const METHOD_PURGE = 'PURGE';
+    const METHOD_OPTIONS = 'OPTIONS';
+    const METHOD_TRACE = 'TRACE';
+    const METHOD_CONNECT = 'CONNECT';
+}


### PR DESCRIPTION
Example:

```php
<?php
class Request extends ServerRequest implements
    RequestInterface, RequestMethodInterface 
{
    public function __construct(
        $uri = '/',
        $method = Request::METHOD_GET,
        array $server = array(), 
        array $query = array(), 
        array $parsedBody = array(), 
        array $cookies = array(), 
        array $files = array()
    ) {
        //...
    }
}

$request = new Http\Request(
            '/', 
            Request::METHOD_GET,
            $GLOBALS['_SERVER'], 
            $GLOBALS['_GET'],
            $GLOBALS['_POST'],
            $GLOBALS['_COOKIE'], 
            $GLOBALS['_FILES']
        );
```