### PR TITLE
Add homepage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "psr/http-message",
     "description": "Common interface for HTTP messages",
     "keywords": ["psr", "psr-7", "http", "http-message", "request", "response"],
+    "homepage": "https://github.com/php-fig/http-message",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
Including the homepage link makes package mirrors and directories such as those generated by Satis nicer to read and more useful (providing a direct link to the project page).