### PR TITLE
Update RequestInterface.php

### DIFF
--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -105,7 +105,7 @@ interface RequestInterface extends MessageInterface
      *
      * You can opt-in to preserving the original state of the Host header by
      * setting `$preserveHost` to `true`. When `$preserveHost` is set to
-     * `true`, this method interacts with the Host header in the following ways:
+     * `false`, this method interacts with the Host header in the following ways:
      *
      * - If the the Host header is missing or empty, and the new URI contains
      *   a host component, this method MUST update the Host header in the returned


### PR DESCRIPTION
REOPEN: Significant inconsistencies in documentation

http://www.php-fig.org/psr/psr-7/#1-2-http-headers

When this argument is set to true, the returned request will not update the Host header of the returned message -- unless the message contains no Host header.