### PR TITLE
withRequestTarget() accepts string only

### DIFF
--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -55,7 +55,7 @@ interface RequestInterface extends MessageInterface
      *
      * @link http://tools.ietf.org/html/rfc7230#section-5.3 (for the various
      *     request-target forms allowed in request messages)
-     * @param mixed $requestTarget
+     * @param string $requestTarget
      * @return static
      */
     public function withRequestTarget($requestTarget);


### PR DESCRIPTION
As far as I can see, `withRequestTarget()` only accepts a `string`.
