### PR TITLE
phpdoc return type for ServerRequestInterface::getUploadedFiles()

### DIFF
--- a/src/ServerRequestInterface.php
+++ b/src/ServerRequestInterface.php
@@ -131,7 +131,7 @@ interface ServerRequestInterface extends RequestInterface
      * These values MAY be prepared from $_FILES or the message body during
      * instantiation, or MAY be injected via withUploadedFiles().
      *
-     * @return array An array tree of UploadedFileInterface instances; an empty
+     * @return UploadedFileInterface[] An array tree of UploadedFileInterface instances; an empty
      *     array MUST be returned if no data is present.
      */
     public function getUploadedFiles();


### PR DESCRIPTION
For better IDE autocompletion I suggest replace return type for `ServerRequestInterface::getUploadedFiles()` from simple `array` to `UploadedFileInterface[]`