### PR TITLE
add status constants

### DIFF
--- a/src/StatusCode.php
+++ b/src/StatusCode.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Psr\Http\Message;
+
+/**
+ * Describes status codes.
+ */
+class StatusCode
+{
+    const CONTINUE = 100;
+    const SWITCHING_PROTOCOLS = 101;
+    const PROCESSING = 102;
+
+    const OK = 200;
+    const CREATED = 201;
+    const ACCEPTED = 202;
+    const NON_AUTHORITATIVE_INFORMATION = 203;
+    const NO_CONTENT = 204;
+    const RESET_CONTENT = 205;
+    const PARTIAL_CONTENT = 206;
+    const MULTI_STATUS = 207;
+    const ALREADY_REPORTED = 208;
+    const IM_USED = 226;
+
+    const MULTIPLE_CHOICES = 300;
+    const MOVED_PERMANENTLY = 301;
+    const FOUND_MOVED_TEMPORARILY = 302;
+    const SEE_OTHER = 303;
+    const NOT_MODIFIED = 304;
+    const USE_PROXY = 305;
+    const TEMPORARY_REDIRECT = 307;
+    const PERMANENT_REDIRECT = 308;
+
+    const BAD_REQUEST = 400;
+    const UNAUTHORIZED = 401;
+    const PAYMENT_REQUIRED = 402;
+    const FORBIDDEN = 403;
+    const NOT_FOUND = 404;
+    const METHOD_NOT_ALLOWED = 405;
+    const NOT_ACCEPTABLE = 406;
+    const PROXY_AUTHENTICATION_REQUIRED = 407;
+    const REQUEST_TIMEOUT = 408;
+    const CONFLICT = 409;
+    const GONE = 410;
+    const LENGTH_REQUIRED = 411;
+    const PRECONDITION_FAILED = 412;
+    const REQUEST_ENTITY_TOO_LARGE = 413;
+    const URI_TOO_LONG = 414;
+    const UNSUPPORTED_MEDIA_TYPE = 415;
+    const REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+    const EXPECTATION_FAILED = 417;
+    const IM_A_TEAPOT = 418;
+    const POLICY_NOT_FULFILLED = 420;
+    const MISDIRECTED_REQUEST = 421;
+    const UNPROCESSABLE_ENTITY = 422;
+    const LOCKED = 423;
+    const FAILED_DEPENDENCY = 424;
+    const UNORDERED_COLLECTION = 425;
+    const UPGRADE_REQUIRED = 426;
+    const PRECONDITION_REQUIRED = 428;
+    const TOO_MANY_REQUESTS = 429;
+    const REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+    const NO_RESPONSE = 444;
+    const THE_REQUEST_SHOULD_BE_RETRIED_AFTER_DOING_THE_APPROPRIATE_ACTION = 449;
+    const UNAVAILABLE_FOR_LEGAL_REASONS = 451;
+    const CLIENT_CLOSED_REQUEST = 499;
+
+    const INTERNAL_SERVER_ERROR = 500;
+    const NOT_IMPLEMENTED = 501;
+    const BAD_GATEWAY = 502;
+    const SERVICE_UNAVAILABLE = 503;
+    const GATEWAY_TIMEOUT = 504;
+    const HTTP_VERSION_NOT_SUPPORTED = 505;
+    const VARIANT_ALSO_NEGOTIATES = 506;
+    const INSUFFICIENT_STORAGE = 507;
+    const LOOP_DETECTED = 508;
+    const BANDWIDTH_LIMIT_EXCEEDED = 509;
+    const NOT_EXTENDED = 510;
+    const NETWORK_AUTHENTICATION_REQUIRED = 511;
+}


### PR DESCRIPTION
I could not find a PR (also not a closed ones) about this topic. So I've added one to see if there could be something like this in http message.

The goal would be a user of this PSR does not need to remember the status code numbers by them self, but could rely on their  textual representations.

If there was already a discussion on this topic please put a link here and close this PR.