### PR TITLE
replace magic __toString method with toString

### DIFF
--- a/docs/PSR7-Interfaces.md
+++ b/docs/PSR7-Interfaces.md
@@ -78,7 +78,7 @@ Same methods as `Psr\Http\Message\MessageInterface`  + the following methods:
 
 | Method Name                        | Description | Notes |
 |------------------------------------| ----------- | ----- |
-| `__toString()` | Reads all data from the stream into a string, from the beginning to end. | |
+| `toString()` | Reads all data from the stream into a string, from the beginning to end. | |
 | `close()` | Closes the stream and any underlying resources. | |
 | `detach()` | Separates any underlying resources from the stream. | |
 | `getSize()` | Get the size of the stream if known. | |
@@ -112,7 +112,7 @@ Same methods as `Psr\Http\Message\MessageInterface`  + the following methods:
 | `withPath($path)` | Return an instance with the specified path. | |
 | `withQuery($query)` | Return an instance with the specified query string. | |
 | `withFragment($fragment)` | Return an instance with the specified URI fragment. | |
-| `__toString()` | Return the string representation as a URI reference. | |
+| `toString()` | Return the string representation as a URI reference. | |
 
 ## `Psr\Http\Message\UploadedFileInterface` Methods
 

--- a/src/StreamInterface.php
+++ b/src/StreamInterface.php
@@ -25,7 +25,7 @@ interface StreamInterface
      * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
      * @return string
      */
-    public function __toString();
+    public function toString();
 
     /**
      * Closes the stream and any underlying resources.

--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -308,7 +308,7 @@ interface UriInterface
      * - If an authority is present, it MUST be prefixed by "//".
      * - The path can be concatenated without delimiters. But there are two
      *   cases where the path has to be adjusted to make the URI reference
-     *   valid as PHP does not allow to throw an exception in __toString():
+     *   valid:
      *     - If the path is rootless and an authority is present, the path MUST
      *       be prefixed by "/".
      *     - If the path is starting with more than one "/" and no authority is
@@ -319,5 +319,5 @@ interface UriInterface
      * @see http://tools.ietf.org/html/rfc3986#section-4.1
      * @return string
      */
-    public function __toString();
+    public function toString();
 }


### PR DESCRIPTION
What if we've replaced the magic __toString method with a regular toString method, would make the usage nicer.