### PR TITLE
declare `__toString` as `@throws void`

### DIFF
--- a/src/StreamInterface.php
+++ b/src/StreamInterface.php
@@ -21,6 +21,7 @@ interface StreamInterface
      *
      * This method MUST NOT raise an exception in order to conform with PHP's
      * string casting operations.
+     * @throws void
      *
      * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
      * @return string


### PR DESCRIPTION
with this change static analysis tools are able to detect implementations which throw.

see https://phpstan.org/r/90fcf22e-b99b-4455-bf32-a9a7078fbb39