### PR TITLE
UrlInterface->withQueryParameter()

### DIFF
--- a/src/UriInterface.php
+++ b/src/UriInterface.php
@@ -279,6 +279,23 @@ interface UriInterface
      * @throws \InvalidArgumentException for invalid query strings.
      */
     public function withQuery($query);
+    
+    /**
+     * Return an instance with the specified query parameter added to existing query string.
+     *
+     * This method MUST retain the state of the current instance, and return
+     * an instance that contains the specified query string.
+     *
+     * Users can provide both encoded and decoded query characters.
+     * Implementations ensure the correct encoding as outlined in getQuery().
+     *
+     * A null query parameter value is equivalent to removing the query parameter.
+     *
+     * @param string $name The query parameter to use with the new instance.
+     * @param string|null $value Value of the query parameter.
+     * @return static A new instance with the specified query parameter.
+     */
+    public function withQueryParameter($name, $value);
 
     /**
      * Return an instance with the specified URI fragment.


### PR DESCRIPTION
In comparation with other http (client) implementations I really like PSR-7/17/18 has method for everything, instead of building request from a huge array. One method I am missing is for single query parameter. Currently it's possible to configure whole request through interface. Just query parameters have to be passed around in an array before building an query string. I think it would be nice quality of life improvement to have method just for that.