### PR TITLE
docs: Fix Content-Type return value

### DIFF
--- a/docs/PSR7-Usage.md
+++ b/docs/PSR7-Usage.md
@@ -56,7 +56,7 @@ $response->getHeaderLine('My-Custom-Header'); // will return:  "My Custom Messag
 #### Getting array of value from a header (also applies to request)
 ```php
 // getting value from request headers
-$request->getHeader('Content-Type'); // will return: ["text/html", "charset=UTF-8"]
+$request->getHeader('Content-Type'); // will return: ["text/html; charset=UTF-8"]
 // getting value from response headers
 $response->getHeader('My-Custom-Header'); // will return:  ["My Custom Message",  "The second message"]
 ```


### PR DESCRIPTION
The example implied that the header would be split along semicolons but those just separate parameters within a single Content-Type header:
https://www.rfc-editor.org/rfc/rfc2616#section-14.17
Multiple Content-Type headers are not permitted anyway, as the header does not accept a comma-separated list:
https://www.rfc-editor.org/rfc/rfc2616#section-4.2
