### PR TITLE
Use more precise return type for StreamInterface::getMetadata

### DIFF
--- a/src/StreamInterface.php
+++ b/src/StreamInterface.php
@@ -150,9 +150,10 @@ interface StreamInterface
      *
      * @link http://php.net/manual/en/function.stream-get-meta-data.php
      * @param string $key Specific metadata to retrieve.
-     * @return array|mixed|null Returns an associative array if no key is
+     * @return array<string, mixed>|mixed|null Returns an associative array if no key is
      *     provided. Returns a specific key value if a key is provided and the
      *     value is found, or null if the key is not found.
+     * @phpstan-return ($key is null ? array<string, mixed> : mixed|null)
      */
     public function getMetadata($key = null);
 }


### PR DESCRIPTION
The array keys are always strings.

And when `null` is passed as `$key` argument, it should always return an array. But that can be only concisely expressed in PHPStan – Psalm requires a template type for conditional types. So let’s use prefixed annotation.
