### PR TITLE
Add .gitattributes with export ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 /docs           export-ignore
-/CHANGELOG.md   export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/docs           export-ignore
+/CHANGELOG.md   export-ignore


### PR DESCRIPTION
This PR will decrease the size of the distribution by 15.74 KB by removing files that are not used in prod environment (except for licenses)